### PR TITLE
Fix PD_ses z-scores

### DIFF
--- a/R/PD_ses.R
+++ b/R/PD_ses.R
@@ -84,7 +84,7 @@ PD_ses <- function(x, phy,
     y <- do.call(rbind, rand)
     rand.mean <- apply(X = y, MARGIN = 2, FUN = mean, na.rm = TRUE)
     rand.sd <- apply(X = y, MARGIN = 2, FUN = sd, na.rm = TRUE)
-    obs.z <- (obs - rand.mean)/sqrt(rand.sd)
+    obs.z <- (obs - rand.mean)/rand.sd
     obs.rank <- apply(X = rbind(obs, y), MARGIN = 2, FUN = rank)[1, ]
     obs.rank <- ifelse(is.na(rand.mean), NA, obs.rank)
     pvalue <- obs.rank/(length(rand)+1)


### PR DESCRIPTION
Addresses #19, using the standard deviation of the null model values, instead of its square root